### PR TITLE
Add csrf token on page load

### DIFF
--- a/ui/App.js
+++ b/ui/App.js
@@ -9,7 +9,21 @@ import MissingPageView from './views/MissingPageView';
 
 const App = () => {
   const client = new ApolloClient({
-    uri: process.env.GRAPHQL_API_URL
+    uri: process.env.GRAPHQL_API_URL,
+    credentials: 'include',
+    request: (operation) => {
+      const csrfMetaTag = document.querySelector('meta[name=csrf-token]');
+
+      if (!csrfMetaTag) {
+        return;
+      }
+
+      operation.setContext({
+        headers: {
+          'X-CSRF-Token': csrfMetaTag.getAttribute('content'),
+        },
+      })
+    },
   });
 
   return (


### PR DESCRIPTION
Reason: Add necessary CSRF token to ApolloClient to stop error: `Can't verify CSRF token authenticity.`